### PR TITLE
fix: use `biome` over `dprint` if both are installed

### DIFF
--- a/lint-staged.sh
+++ b/lint-staged.sh
@@ -112,18 +112,18 @@ if [ ${#JSON_FILES} -gt 1 ]; then
     # shellcheck disable=SC2086
     jsona fmt --option trailing_newline=true --check ${JSON_FILES}
     log "JSON [jsona] linting done"
-  elif [ "$(command -v dprint)" ] && [ -f "./dprint.json" ]; then
-    log "jsona binary is not installed but dprint binary was found"
-    log "JSON [dprint] linting..."
-    # shellcheck disable=SC2086
-    dprint check ${JSON_FILES}
-    log "JSON [dprint] linting done"
-  elif [ "$(command -v biome)" ] && [ -f "./biome.json" ]; then
-    log "jsona and dprint binaries are not installed but biome binary was found"
+  elif [ "$(command -v dprint)" ] && [ -f "./biome.json" ]; then
+    log "jsona binary is not installed but biome binary was found"
     log "JSON [biome] linting..."
     # shellcheck disable=SC2086
     biome format ${JSON_FILES}
     log "JSON [biome] linting done"
+  elif [ "$(command -v dprint)" ] && [ -f "./dprint.json" ]; then
+    log "jsona and biome binaries are not installed but dprint binary was found"
+    log "JSON [dprint] linting..."
+    # shellcheck disable=SC2086
+    dprint check ${JSON_FILES}
+    log "JSON [dprint] linting done"
   else
     log "jsona, dprint and biome binaries are not installed"
   fi


### PR DESCRIPTION
# Pull Request: {REASON HERE}

## What you changed

- [ ] Code changes
- [ ] Tests changed
- [ ] Typo fixes

## Type package name

> If you change code, tests should be passed
